### PR TITLE
Fixed Bug with strip width calculation

### DIFF
--- a/jquery.webticker.js
+++ b/jquery.webticker.js
@@ -55,7 +55,13 @@
 	function initalize($strip){
 		var settings = globalSettings[$strip.attr('id')];
 		$strip.width('auto');
-		var stripWidth = $strip.width();
+		
+		//Find the real width of all li elements
+		var stripWidth = 0;
+		$strip.children('li').each(function(){
+			stripWidth += $(this).outerWidth( true );
+		}); 
+		
 		if(stripWidth < $strip.parent().width() || $strip.children().length == 1){
 			//if duplicate items
 			if (settings.duplicate){


### PR DESCRIPTION
$strip.width() would return the original size.

Instead we have to manually get the width of all the li elements and use that as our strip width.

This caused the problem if the text was < strip width, the text would jump rather than coming from the side of the strip

Fixes #7
