### PR TITLE
Init RssList w/ empty list instead of undefined

### DIFF
--- a/jquery.webticker.js
+++ b/jquery.webticker.js
@@ -72,7 +72,7 @@
 	}
 
 	function updaterss(rssurl,type,$strip){
-		var list;
+		var list = [];
 		$.get(rssurl, function(data) {
 		    var $xml = $(data);
 		    $xml.find("item").each(function() {


### PR DESCRIPTION
Details:
- The updaterss function maps the found "item" elements from the fetched rss by turning them into line item elements and adding them to the "list" javascript variable, from which the new ticker is generated. However, the "var list;" declaration does not define a value for list, leaving it undefined. Thus the operation += is an operation on "undefined", which causes errors. Eg. Chrome Version 33.0.1750.146
- The fix is to set the list to an empty array.
