### PR TITLE
RSS improvements: fix updatetype handling, adds optional pubdate and category classes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,10 +22,10 @@ The update functionality supports two modes 'swap' and 'reset' which are set acc
 
 	$("#webticker").webTicker('update','<li data-update="item1">First News Item Updated</li><li data-update="item3">Third News Item Updated</li><li data-update="item4">Fourth News Item Updated</li><li data-update="item9">Ninth News Item Updated</li><li data-update="itemnew1">This is New Item 1</li><li  data-update="itemnew2">This is New Item 2</li><li  data-update="itemnew3">This is New Item 3</li><li  data-update="itemnew4">This is New Item 4</li>','swap',[insert],[remove]);
 
-The swap functionality uses `data-update` attributes to identify uniquie items in the list. 
+The swap functionality uses `data-update` attributes to identify uniquie items in the list.
 When a node value is changed this is just 'swapped' leaving it in the same positions.
-Items not in the 'update' list are not removed whilst new ones would be added at the end. 
-This behaviour can be altered by passing the last two parameters, insert & remove. 
+Items not in the 'update' list are not removed whilst new ones would be added at the end.
+This behaviour can be altered by passing the last two parameters, insert & remove.
 A boolean value of `true` would indicate new items to be added/removed respectively.
 
 On the other-hand the `reset` just clears the list and starts afresh.
@@ -37,6 +37,19 @@ Rss Feeds are now automatically supported by the ticker; note that as per javasc
 	$("#webticker").webTicker({rssurl:'http://yourwebsite.com/rss/', rssfrequency:5});
 
 The above command will automatically pull up the RSS feed from your website & update every 5 minutes.
+
+Provide an optional dateformatter function to parse and format pubDate strings.  These will be shown in a
+<span class='pubdate'>...</span> tag.  If not provided, dates won't be shown.
+
+Item categories will be used to add category-* classes to each item. For example, an RSS item with a
+"Top Stories" category label will be marked with <li class="category-top-stories"> ... </li>.
+
+The example in example/rss.html requires npm's [corsproxy](https://www.npmjs.com/package/corsproxy) to proxy the RSS feed data locally.  First install and run it:
+
+	npm install -g corsproxy
+	corsproxy
+
+and then open example/rss.html in your browser.
 
 
 ## Settings - Optional
@@ -50,6 +63,7 @@ Below find a list of settings and the relative default values.
 	duplicate: false, //if there is less items then visible on the ticker you can duplicate the items to make it continuous
 	rssurl: false, //only set if you want to get data from rss
 	rssfrequency: 0, //the frequency of updates in minutes. 0 means do not refresh
+	dateformatter: function(s) { return new Date(s).toString(); }  // format pubDate strings
 	updatetype: "reset" //how the update would occur options are "reset" or "swap"
 	hoverpause: true //pause the ticker when hovered
 
@@ -90,7 +104,7 @@ ul.newsticker
 
 .tickeroverlay-left , .tickeroverlay-right
 
-	background-image:...//can both be used to achieve a fade-in and fade-out effect 
+	background-image:...//can both be used to achieve a fade-in and fade-out effect
 
 ## Licence
 

--- a/README.markdown
+++ b/README.markdown
@@ -39,10 +39,10 @@ Rss Feeds are now automatically supported by the ticker; note that as per javasc
 The above command will automatically pull up the RSS feed from your website & update every 5 minutes.
 
 Provide an optional dateformatter function to parse and format pubDate strings.  These will be shown in a
-<span class='pubdate'>...</span> tag.  If not provided, dates won't be shown.
+`<span class='pubdate'>...</span>` tag.  If not provided, dates won't be shown.
 
 Item categories will be used to add category-* classes to each item. For example, an RSS item with a
-"Top Stories" category label will be marked with <li class="category-top-stories"> ... </li>.
+"Top Stories" category label will be marked with `<li class="category-top-stories"> ... </li>`.
 
 The example in example/rss.html requires npm's [corsproxy](https://www.npmjs.com/package/corsproxy) to proxy the RSS feed data locally.  First install and run it:
 

--- a/example/bbcnews.html
+++ b/example/bbcnews.html
@@ -1,0 +1,71 @@
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+<title>BBC News Ticker</title>
+<style>
+body {
+  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  color: #34302d;
+}
+
+.tickercontainer {
+width: 100%;
+height: 27px;
+margin: 0;
+padding: 0;
+overflow: hidden;
+}
+.tickercontainer .mask {
+position: relative;
+top: 8px;
+height: 18px;
+overflow: hidden;
+}
+ul.newsticker {
+-webkit-transition: all 0s linear;
+-moz-transition: all 0s linear;
+-o-transition: all 0s linear;
+transition: all 0s linear;
+position: relative;
+font: 10px;
+list-style-type: none;
+margin: 0;
+padding: 0;
+}
+ul.newsticker li {
+float: left;
+margin: 0;
+padding: 0 7px;
+box-sizing:border-box;
+}
+.hhmm {
+    color: #666;
+    font-weight: bold;
+    padding-right: 0.5em;
+    font-size: 80%;
+}
+
+</style>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script src="../jquery.webticker.js" type="text/javascript"></script>
+
+</head>
+<body>
+  <ul id="webticker"></ul>
+  <script type="text/javascript">
+$("#webticker").webTicker({
+    speed: 50, //pixels per second
+    direction: "left", //if to move left or right
+    moving: true, //weather to start the ticker in a moving or static position
+    startEmpty: true, //weather to start with an empty or pre-filled ticker
+    duplicate: false, //if there is less items then visible on the ticker you can duplicate the items to make it continuous
+    rssurl: "http://localhost:1337/feeds.bbci.co.uk/news/rss.xml?edition=int", //only set if you want to get data from rss
+    rssfrequency: 1, //the frequency of updates in minutes. 0 means do not refresh
+    updatetype: "swap" //how the update would occur options are "reset" or "swap"
+});
+  </script>
+
+</body>
+</html>

--- a/example/rss.html
+++ b/example/rss.html
@@ -40,11 +40,14 @@ margin: 0;
 padding: 0 7px;
 box-sizing:border-box;
 }
-.hhmm {
+.newsticker .pubdate {
     color: #666;
     font-weight: bold;
     padding-right: 0.5em;
     font-size: 80%;
+}
+li.category-top-stories {
+  font-weight: bold;
 }
 
 </style>
@@ -61,8 +64,9 @@ $("#webticker").webTicker({
     moving: true, //weather to start the ticker in a moving or static position
     startEmpty: true, //weather to start with an empty or pre-filled ticker
     duplicate: false, //if there is less items then visible on the ticker you can duplicate the items to make it continuous
-    rssurl: "http://localhost:1337/feeds.bbci.co.uk/news/rss.xml?edition=int", //only set if you want to get data from rss
+    rssurl: "http://localhost:1337/news.google.com/news?pz=1&cf=all&ned=us&hl=en&output=rss", //only set if you want to get data from rss
     rssfrequency: 1, //the frequency of updates in minutes. 0 means do not refresh
+    dateformatter: function(dt) { return new Date(dt).toString() },
     updatetype: "swap" //how the update would occur options are "reset" or "swap"
 });
   </script>

--- a/jquery.webticker.js
+++ b/jquery.webticker.js
@@ -74,7 +74,7 @@
 	function updaterss(rssurl,type,$strip){
 		var list = [];
 		$.get(rssurl, function(data) {
-		    var $xml = $(data);
+		    var $xml = $($.parseXML(data));
 		    $xml.find("item").each(function() {
 		        var $this = $(this),
 		            item = {

--- a/jquery.webticker.js
+++ b/jquery.webticker.js
@@ -71,22 +71,37 @@
 		$strip.css(options.css).css('transition-duration',time);
 	}
 
-	function updaterss(rssurl,type,$strip){
+	function updaterss(rssurl,type,dateformatter,$strip){
 		var list = [];
 		$.get(rssurl, function(data) {
-		    var $xml = $($.parseXML(data));
+		    var $xml = $(data);
 		    $xml.find("item").each(function() {
 		        var $this = $(this),
 		            item = {
 		                title: $this.find("title").text(),
-		                link: $this.find("link").text()
-		        }
-		        listItem = "<li><a href='"+item.link+"'>"+item.title+"</a></li>";
+		                link: $this.find("link").text(),
+		                pubDate: $this.find("pubDate").text(),
+		                categories: $this.find("category").map(function(i, c) {
+						    return 'category-' + c.textContent.replace(/[^a-z0-9]/g, function(s) {
+						        var c = s.charCodeAt(0);
+						        if (c == 32) return '-';
+						        if (c >= 65 && c <= 90) return s.toLowerCase();
+						        return '_';
+						    });
+						}).get()
+	                };
+		        listItem = "<li "
+		        	// possibly insert categories as class tags
+		        	+ (item.categories ? "class='" + item.categories.join(' ') + "'" : "")
+		        	+ ">"
+		        	// possibly insert formatted date
+		        	+ ((dateformatter && item.pubDate) ? "<span class='pubdate'>" + dateformatter(item.pubDate) + "</span>" : "")
+		        	+ "<a href='"+item.link+"'>"+item.title+"</a></li>";
 		        list += listItem;
 		        //Do something with item here...
 		    });
 			$strip.webTicker('update', list, type);
-		});
+		}, "xml");
 	}
 
 	function initalize($strip){
@@ -187,9 +202,9 @@
 				var started = initalize($strip);
 
 				if (settings.rssurl){
-					updaterss(settings.rssurl,settings.type,$strip);
+					updaterss(settings.rssurl,settings.updatetype,settings.dateformatter,$strip);
 					if (settings.rssfrequency>0){
-						window.setInterval(function(){updaterss(settings.rssurl,settings.type,$strip);},settings.rssfrequency*1000*60);
+						window.setInterval(function(){updaterss(settings.rssurl,settings.updatetype,settings.dateformatter,$strip);},settings.rssfrequency*1000*60);
 					}
 				}
 


### PR DESCRIPTION
Fixes https://github.com/jonmifsud/Web-Ticker/issues/21

Force XML document parsing to avoid messed up "link" parsing in some cases.

Adds optional dateformatter setting to display pubdate in ticker.

Tags items with category-* classes based on RSS category elements, for CSS formatting.