### PR TITLE
Remove resize event - causes browser tab to crash.

### DIFF
--- a/jquery.webticker.js
+++ b/jquery.webticker.js
@@ -209,14 +209,6 @@
 				var $mask = $strip.wrap('<div class="mask"></div>');
 				$mask.after('<span class="tickeroverlay-left">&nbsp;</span><span class="tickeroverlay-right">&nbsp;</span>');
 				var $tickercontainer = $strip.parent().wrap('<div class="tickercontainer"></div>');
-				var resizeEvt; 
-				$(window).resize(function() {
-					clearTimeout(resizeEvt);
-					resizeEvt = setTimeout(function() {
-							console.log('window was resized');
-							initialize($strip,false);
-					}, 500);
-				});
 
 				//adding required css rules
 				


### PR DESCRIPTION
Hi there!

I noticed that the initializing during the resize event was causing my browser tab to crash in Chromium, Firefox, and Safari.

To replicate: 

- Use webticker according to the documentation
- Resize quickly to the minimum browser width
- attempt to resize the browser to full width again.


Listening for the resize event, continuing it, and restarting it once completed like the following in my code seemed to stop this behaviour, with no noticeable errors in functionality.
```
$('#webTicker').webTicker({    height:'75px', 
        duplicate: true, 
        rssfrequency: 0, 
        startEmpty: false, 
        hoverpause: false, 
        speed: 20,
        height: '50px'
    })

$(window).resize(() => {
    $('#webTicker').webTicker('stop')
    clearTimeout(window.resizedFinished);
    window.resizedFinished = setTimeout(function(){
        $('#webTicker').webTicker('cont')
    }, 250);
});
```